### PR TITLE
Read from directories

### DIFF
--- a/admin/handle_configuration.go
+++ b/admin/handle_configuration.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/Everbridge/go-proxy/configuration"
@@ -18,6 +19,26 @@ func handleGetConfigurations(w http.ResponseWriter, req *http.Request) {
 	responseWithJSON(configs, w, req)
 }
 
+func handleSaveConfigurations(w http.ResponseWriter, req *http.Request) {
+	decoder := json.NewDecoder(req.Body)
+	var passedInConfiguration configuration.Configuration
+	err := decoder.Decode(&passedInConfiguration)
+
+	if err != nil {
+		myhttp.InternalError(req, w, err)
+		return
+	}
+
+	err = configuration.SaveConfiguration(passedInConfiguration)
+	if err != nil {
+		myhttp.InternalError(req, w, err)
+		return
+	}
+
+	responseWithJSON(passedInConfiguration, w, req)
+}
+
 func registerConfigurationEndpoints(router *mux.Router) {
 	router.HandleFunc("/api/configurations", handleGetConfigurations).Methods(http.MethodGet)
+	router.HandleFunc("/api/configurations", handleSaveConfigurations).Methods(http.MethodPut)
 }

--- a/admin/handle_configuration.go
+++ b/admin/handle_configuration.go
@@ -1,0 +1,23 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/Everbridge/go-proxy/configuration"
+	myhttp "github.com/Everbridge/go-proxy/http"
+	"github.com/gorilla/mux"
+)
+
+func handleGetConfigurations(w http.ResponseWriter, req *http.Request) {
+	configs, loadErr := configuration.LoadConfiguration()
+	if loadErr != nil {
+		myhttp.InternalError(req, w, loadErr)
+		return
+	}
+
+	responseWithJSON(configs, w, req)
+}
+
+func registerConfigurationEndpoints(router *mux.Router) {
+	router.HandleFunc("/api/configurations", handleGetConfigurations).Methods(http.MethodGet)
+}

--- a/admin/server.go
+++ b/admin/server.go
@@ -41,11 +41,7 @@ func StartAdminServer() error {
 	registerVariablesEndpoints(adminServer)
 	adminServer.HandleFunc("/api/requests", handleRequets)
 
-	indexHTML := box.String("index.html")
-	returnIndexHandler := createReturnIndexHandler(indexHTML)
-	adminServer.HandleFunc("/mappings", returnIndexHandler)
-	adminServer.HandleFunc("/requests", returnIndexHandler)
-	adminServer.HandleFunc("/variables", returnIndexHandler)
+	registerReturnToIndexEndpoints(adminServer, box, "/configurations", "/mappings", "/requests", "/variables")
 
 	adminServer.Handle("/{file:.*}", http.FileServer(box))
 
@@ -55,5 +51,14 @@ func StartAdminServer() error {
 func createReturnIndexHandler(indexHTML string) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte(indexHTML))
+	}
+}
+
+func registerReturnToIndexEndpoints(router *mux.Router, box packr.Box, paths ...string) {
+	indexHTML := box.String("index.html")
+	returnIndexHandler := createReturnIndexHandler(indexHTML)
+
+	for _, path := range paths {
+		router.HandleFunc(path, returnIndexHandler)
 	}
 }

--- a/admin/server.go
+++ b/admin/server.go
@@ -36,6 +36,7 @@ func StartAdminServer() error {
 	fmt.Printf("Opening admin server at: http://localhost:%d\n", adminServerPort)
 
 	adminServer := mux.NewRouter()
+	registerConfigurationEndpoints(adminServer)
 	registerMappingsEndpoints(adminServer)
 	registerVariablesEndpoints(adminServer)
 	adminServer.HandleFunc("/api/requests", handleRequets)

--- a/configuration/configuration_file.go
+++ b/configuration/configuration_file.go
@@ -1,0 +1,34 @@
+package configuration
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+const configFileName = ".config"
+
+// LoadConfiguration loads the current user configuration
+func LoadConfiguration() (*Configuration, error) {
+	configDir, dirErr := GetConfigurationDirectory()
+	if dirErr != nil {
+		return nil, dirErr
+	}
+
+	result := new(Configuration)
+	result.BaseDirectories = make([]string, 0)
+
+	configContent, readErr := ioutil.ReadFile(path.Join(configDir, configFileName))
+	if os.IsNotExist(readErr) {
+		return result, nil
+	}
+
+	if readErr != nil {
+		return nil, readErr
+	}
+
+	unmarshalErr := yaml.Unmarshal(configContent, result)
+	return result, unmarshalErr
+}

--- a/configuration/configuration_file.go
+++ b/configuration/configuration_file.go
@@ -32,3 +32,18 @@ func LoadConfiguration() (*Configuration, error) {
 	unmarshalErr := yaml.Unmarshal(configContent, result)
 	return result, unmarshalErr
 }
+
+// SaveConfiguration saves a configuration to the file
+func SaveConfiguration(toSave Configuration) error {
+	data, marshalErr := yaml.Marshal(toSave)
+	if marshalErr != nil {
+		return marshalErr
+	}
+
+	configDir, dirErr := GetConfigurationDirectory()
+	if dirErr != nil {
+		return dirErr
+	}
+
+	return ioutil.WriteFile(path.Join(configDir, configFileName), data, 0644)
+}

--- a/configuration/model.go
+++ b/configuration/model.go
@@ -1,0 +1,7 @@
+package configuration
+
+// Configuration stores general configuration for the proxy
+type Configuration struct {
+	// BaseDirectories stores all the places where configuration files can be found
+	BaseDirectories []string
+}

--- a/mapping/file_walker.go
+++ b/mapping/file_walker.go
@@ -1,0 +1,36 @@
+package mapping
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+	"strings"
+	"sync"
+)
+
+var callbackLock sync.Mutex
+
+func walkDir(pathToDir string, wg *sync.WaitGroup, callback func(string, bool)) {
+	defer wg.Done()
+
+	if strings.HasSuffix(pathToDir, "/.git") {
+		return
+	}
+
+	files, readDirErr := ioutil.ReadDir(pathToDir)
+	if readDirErr != nil {
+		fmt.Printf("Error while reading directory: %s\n%s\n", pathToDir, readDirErr.Error())
+		return
+	}
+
+	for _, fileInfo := range files {
+		pathToFile := path.Join(pathToDir, fileInfo.Name())
+		if fileInfo.IsDir() {
+			wg.Add(1)
+			go walkDir(pathToFile, wg, callback)
+		}
+		callbackLock.Lock()
+		callback(pathToFile, fileInfo.IsDir())
+		callbackLock.Unlock()
+	}
+}

--- a/mapping/file_walker.go
+++ b/mapping/file_walker.go
@@ -22,6 +22,7 @@ func walkDirectories(directories []string, callback func(string, bool)) {
 	}
 
 	wg.Wait()
+	close(directoriesToVisit)
 }
 
 func readDirectories(directoriesToVisit chan string, wg *sync.WaitGroup, callbackLock *sync.Mutex, callback func(string, bool)) {

--- a/mapping/mappings_from_file.go
+++ b/mapping/mappings_from_file.go
@@ -5,8 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"os"
-	"path"
 	"sort"
 	"strings"
 
@@ -30,16 +28,16 @@ func generateID(mapping Mapping) string {
 	return base64.URLEncoding.EncodeToString(hasher.Sum(nil))
 }
 
-func loadMappingsFromFiles(mappingDir string, file os.FileInfo) ([]Mapping, error) {
+func loadMappingsFromFiles(pathToFile string) ([]Mapping, error) {
 	mappings := make([]Mapping, 0)
 
-	mappingsFromFile, mappingErr := readMappingFile(path.Join(mappingDir, file.Name()))
+	mappingsFromFile, mappingErr := readMappingFile(pathToFile)
 	if mappingErr != nil {
-		return nil, fmt.Errorf("Error while reading configuration file: %s\n%s", file.Name(), mappingErr)
+		return nil, fmt.Errorf("Error while reading configuration file: %s\n%s", pathToFile, mappingErr)
 	}
 
-	mappings = append(mappings, mappingFromYamlMapping(mappingsFromFile.Static, file.Name(), false, mappingsFromFile.Tags)...)
-	mappings = append(mappings, mappingFromYamlMapping(mappingsFromFile.Proxy, file.Name(), true, mappingsFromFile.Tags)...)
+	mappings = append(mappings, mappingFromYamlMapping(mappingsFromFile.Static, pathToFile, false, mappingsFromFile.Tags)...)
+	mappings = append(mappings, mappingFromYamlMapping(mappingsFromFile.Proxy, pathToFile, true, mappingsFromFile.Tags)...)
 
 	return mappings, nil
 }

--- a/static/js/components/Application.js
+++ b/static/js/components/Application.js
@@ -2,6 +2,7 @@ import { Icon, Menu } from 'semantic-ui-react';
 import { BrowserRouter as Router, Link, Route } from 'react-router-dom';
 import React from 'react';
 
+import Configurations from './Configurations';
 import Mappings from './Mappings';
 import Requests from './Requests';
 import Variables from './Variables';
@@ -22,6 +23,7 @@ export default class Application extends React.Component {
       <Route exact path="/mappings" component={Mappings}/>
       <Route exact path="/requests" component={Requests}/>
       <Route exact path="/variables" component={Variables}/>
+      <Route exact path="/configurations" component={Configurations}/>
     </React.Fragment>;
   }
 
@@ -36,6 +38,7 @@ export default class Application extends React.Component {
       <Menu.Item><Link to="/requests">Requests</Link></Menu.Item>
       <Menu.Item><Link to="/mappings">Mappings</Link></Menu.Item>
       <Menu.Item><Link to="/variables">Variables</Link></Menu.Item>
+      <Menu.Item><Link to="/configurations">Configurations</Link></Menu.Item>
     </Menu>;
   }
 

--- a/static/js/components/Configurations.js
+++ b/static/js/components/Configurations.js
@@ -1,0 +1,34 @@
+import { Icon, Label } from 'semantic-ui-react';
+import { inject, observer } from 'mobx-react';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+@inject('configurations')
+@observer
+export default class Variables extends React.Component {
+  static propTypes = {
+    configurations: PropTypes.object.isRequired,
+  }
+
+  render() {
+    const { data, loading } = this.props.configurations;
+    if (loading) {
+      return <p>Loading...</p>;
+    }
+
+    return <div>
+      <h3>Base Directories</h3>
+      <p><Icon name="add circle" size="large" /></p>
+      {data.BaseDirectories.map(this.renderBaseDirectory)}
+    </div>;
+  }
+
+  renderBaseDirectory(baseDir) {
+    return <div key={baseDir}>
+      <Label>
+        {baseDir}
+        <Icon name="delete" />
+      </Label>
+    </div>;
+  }
+}

--- a/static/js/components/Configurations.js
+++ b/static/js/components/Configurations.js
@@ -1,4 +1,4 @@
-import { Icon, Label } from 'semantic-ui-react';
+import { Icon, Input, Label } from 'semantic-ui-react';
 import { inject, observer } from 'mobx-react';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -10,6 +10,45 @@ export default class Variables extends React.Component {
     configurations: PropTypes.object.isRequired,
   }
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      adding: false,
+      addedText: "",
+    };
+  }
+
+  handleAddedTextChange(e) {
+    const newValue = e.target.value;
+    this.setState({ addedText: newValue });
+  }
+
+  handleClickAddBaseDirectory() {
+    this.setState({ adding: true });
+  }
+
+  handleAddBaseDirectoryKeyPress(e) {
+    if (e.key === 'Enter') {
+      this.handleSaveBaseDirectory();
+    }
+  }
+
+  handleRemoveBaseDirectory(toRemove) {
+    const { configurations } = this.props;
+    const { data } = configurations;
+    const indexOf = data.BaseDirectories.indexOf(toRemove);
+    data.BaseDirectories.splice(indexOf, 1);
+    configurations.save(data);
+  }
+
+  handleSaveBaseDirectory() {
+    const { configurations } = this.props;
+    const { data } = configurations;
+    data.BaseDirectories.push(this.state.addedText);
+    configurations.save(data);
+    this.setState({ adding: false, addedText: "" });
+  }
+
   render() {
     const { data, loading } = this.props.configurations;
     if (loading) {
@@ -18,16 +57,55 @@ export default class Variables extends React.Component {
 
     return <div>
       <h3>Base Directories</h3>
-      <p><Icon name="add circle" size="large" /></p>
-      {data.BaseDirectories.map(this.renderBaseDirectory)}
+      {this.renderAddBaseDirectory()}
+      {data.BaseDirectories.map((baseDir) => this.renderBaseDirectory(baseDir))}
+    </div>;
+  }
+
+  renderAddBaseDirectory() {
+    const { adding, addedText } = this.state;
+    if (adding) {
+      return <div className="addBaseDirectory">
+        <Input
+          onChange={this.handleAddedTextChange.bind(this)}
+          onKeyPress={this.handleAddBaseDirectoryKeyPress.bind(this)}
+          ref={(input) => { input ? input.focus() : null }}
+          value={addedText}
+        />
+        <Icon
+          color="teal"
+          name="save"
+          onClick={this.handleSaveBaseDirectory.bind(this)}
+          size="large"
+        />
+        <Icon
+          color="red"
+          name="cancel"
+          onClick={() => this.setState({ adding: false })}
+          size="large"
+        />
+      </div>;
+    }
+
+    return <div className="addBaseDirectory">
+      <Icon
+        className="clickable"
+        name="add circle"
+        onClick={this.handleClickAddBaseDirectory.bind(this)}
+        size="large"
+      />
     </div>;
   }
 
   renderBaseDirectory(baseDir) {
-    return <div key={baseDir}>
-      <Label>
+    return <div className="baseDirectory" key={baseDir}>
+      <Label size="large">
         {baseDir}
-        <Icon name="delete" />
+        <Icon
+          color="red"
+          name="delete"
+          onClick={this.handleRemoveBaseDirectory.bind(this, baseDir)}
+        />
       </Label>
     </div>;
   }

--- a/static/js/components/Variables.js
+++ b/static/js/components/Variables.js
@@ -138,16 +138,16 @@ export default class Variables extends React.Component {
     
     const result = values.map(value => {
       if (value === selectedValue) {
-        return <Label key={value} color='olive'>{value}</Label>
+        return <Label key={value} color="olive" size="large">{value}</Label>
       } else {
-        return <Label className="clickable" key={value} onClick={(e) => this.handleSelectionChange(variable, value)}>
+        return <Label className="clickable" key={value} onClick={(e) => this.handleSelectionChange(variable, value)} size="large">
           {value}
           <Icon color="red" name="delete" onClick={(e) => this.handleDeleteValue(e, variable, value)} />
         </Label>
       }
     });
 
-    result.push(<Icon key="add" name="add circle" onClick={() => this.handleAddValue(variable)} />);
+    result.push(<Icon className="clickable" key="add" name="add circle" onClick={() => this.handleAddValue(variable)} size="large" />);
     return result;
   }
 

--- a/static/js/stores/Configurations.js
+++ b/static/js/stores/Configurations.js
@@ -1,0 +1,20 @@
+import axios from 'axios';
+import { action, observable } from 'mobx';
+
+export default class Configurations {
+  @observable data = {};
+  @observable loading = false;
+
+  @action
+  fetch() {
+    this.loading = true;
+    return axios.get('/api/configurations')
+      .then(({data}) => this.setData(data));
+  }
+
+  @action
+  setData(data) {
+    this.data = data;
+    this.loading = false;
+  }
+}

--- a/static/js/stores/Configurations.js
+++ b/static/js/stores/Configurations.js
@@ -13,6 +13,13 @@ export default class Configurations {
   }
 
   @action
+  save(configurations) {
+    this.loading = true;
+    return axios.put('/api/configurations', configurations)
+      .then(({data}) => this.setData(data));
+  }
+
+  @action
   setData(data) {
     this.data = data;
     this.loading = false;

--- a/static/js/stores/index.js
+++ b/static/js/stores/index.js
@@ -1,8 +1,12 @@
+import Configurations from './Configurations';
 import Mappings from './Mappings';
 import PossibleValues from './PossibleValues';
 import ProxiedRequests from './ProxiedRequests';
 import SelectedValues from './SelectedValues';
 import Variables from './Variables';
+
+const configurations = new Configurations();
+configurations.fetch();
 
 const mappings = new Mappings();
 mappings.fetch();
@@ -19,6 +23,7 @@ const variables = new Variables();
 variables.fetch();
 
 export default {
+  configurations,
   mappings,
   possibleValues,
   proxiedRequests,

--- a/static/less/index.less
+++ b/static/less/index.less
@@ -1,3 +1,11 @@
+.addBaseDirectory {
+  margin: 10px 0;
+}
+
+.baseDirectory {
+  margin: 5px 0;
+}
+
 body {
   padding: 10px;
 }


### PR DESCRIPTION
Adds a configuration struct that gets saved to the configuration directory and stores a list of base directories that will be scanned looking for a file `go-proxy.yml` (or `.yaml`). If found, it will add the file to the list of mappings.

Also adds new tab on the Admin UI where base directories can be added or removed. This is how it looks like:

<img width="557" alt="screen shot 2018-10-06 at 8 53 23 am" src="https://user-images.githubusercontent.com/143627/46571610-d8154880-c945-11e8-840a-993c70586de7.png">

Fixes #14.