### PR TITLE
Fix upload large binary file

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -4,5 +4,5 @@ echo --- Running the build ---
 bin/build.sh
 
 echo --- Tagging commit ---
-git tag "v0.7.3"
+git tag "v0.7.4"
 git push --tags

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -104,12 +104,12 @@ func getData(req *http.Request) (statistics.HTTPData, error) {
 		return result, bodyErr
 	}
 
+	// Rewind the body
+	req.Body = closeableByteBuffer{bytes.NewBuffer(body)}
+
 	if len(body) != 0 {
 		if myhttp.IsText(req.Header["Content-Type"]...) {
 			result.Body = string(body)
-
-			// Rewind the body
-			req.Body = closeableByteBuffer{bytes.NewBuffer(body)}
 		} else {
 			result.Body = "Binary"
 		}


### PR DESCRIPTION
When uploading large binary files clients do chunked uploads, which requires the server to respond with a `100 Continue`. This would fail because of the following the `Reader` is not replaced with a new, rewinded, not closed copy.
- the request fails with a `http: invalid Read on closed Body` when trying to read
- if remove the close, it fails because no body is actually proxied, since reading the rest of the `Reader` will return no bytes
To fix this, needs to replace the `Reader` with the copied one, that contains all the data, is rewinded and not closed.